### PR TITLE
Add module: hopfarm-limit-fix 0.1.0

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -508,5 +508,15 @@ extensions:
           url: gynt/ucp-extension-citizens
           github-sha: 74b4b610212110f4bd21195efb9d35b0d0c90f04
           github-tag: main
+    - definition:
+        name: hopfarm-limit-fix
+        version: 0.1.0
+        type: module
+      contents:
+        source:
+          method: github
+          url: DDanielDragon/extension-hopfarm-limit-fix
+          github-sha: faa47e3caee09f2d4e518172c4ebe4ef9aaffd19
+          github-tag: main
 
    


### PR DESCRIPTION
Adds hopfarm-limit-fix, a module for Stronghold Crusader (Extreme, 1.41.1).

The AI farm-build gate (0x4CB470) counts existing farms via 0x40AA20 and
compares against the AIV farm limit (field +0x74). That counter checks wheat
(0x1E), apple (0x20) and dairy (0x21) but omits hops (0x1F), so hop farms are
not counted toward the shared limit and become over-represented over long
games. A second, correct copy of the same count at 0x40CB20 includes all four
types; the jump distances show 0x40AA20 is missing the 6 bytes of the 0x1F
comparison.

The module patches the 18-byte comparison block at 0x40AA52 with a single range
check (0x1E-0x21) via AOB scan, so it fails cleanly on unsupported versions.
Confirmed to apply at runtime.

Repo: https://github.com/DDanielDragon/extension-hopfarm-limit-fix
