### PR TITLE
Add modules: hopfarm-limit-fix and aiv-troop-spot-fix

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -510,3 +510,25 @@ extensions:
           github-tag: main
 
    
+    - definition:
+        name: hopfarm-limit-fix
+        version: 0.1.0
+        type: module
+      contents:
+        source:
+          method: github
+          url: DDanielDragon/ucp3-fixes
+          github-sha: e76a826ee6bc73b794ac0873dda8912931066117
+          github-tag: master
+          location: hopfarm-limit-fix
+    - definition:
+        name: aiv-troop-spot-fix
+        version: 0.1.0
+        type: module
+      contents:
+        source:
+          method: github
+          url: DDanielDragon/ucp3-fixes
+          github-sha: e76a826ee6bc73b794ac0873dda8912931066117
+          github-tag: master
+          location: aiv-troop-spot-fix

--- a/recipe.yml
+++ b/recipe.yml
@@ -518,7 +518,7 @@ extensions:
         source:
           method: github
           url: DDanielDragon/ucp3-fixes
-          github-sha: e76a826ee6bc73b794ac0873dda8912931066117
+          github-sha: dedb7ca3125e6e212e0e895c373a7e8ee9258783
           github-tag: master
           location: hopfarm-limit-fix
     - definition:
@@ -529,6 +529,6 @@ extensions:
         source:
           method: github
           url: DDanielDragon/ucp3-fixes
-          github-sha: e76a826ee6bc73b794ac0873dda8912931066117
+          github-sha: dedb7ca3125e6e212e0e895c373a7e8ee9258783
           github-tag: master
           location: aiv-troop-spot-fix


### PR DESCRIPTION
Adds two bug-fix **modules** from the mono-repo [DDanielDragon/ucp3-fixes](https://github.com/DDanielDragon/ucp3-fixes) (referenced via `location`):

### hopfarm-limit-fix (0.1.0)
Hop farms were not counted against the AI's AIV farm limit, so the AI over-built them over long games. Adds hops (`0x1F`) to the farm-count range check at `0x40AA20`.

### aiv-troop-spot-fix (0.1.0)
AI start troops placed in AIV section-2012 rows **9, 11 and 18** were discarded on load (the decoder at `0x4EF840`-`0x4EF869` skips those rows), so they never walked to their positions - most visibly the Arabic lords' swordsmen (row 18). Firefly fixed this for the DE; the original engine never was. The fix NOPs the three skip jumps so all rows load. Verified on Crusader Extreme by live memory read and observation.

Both are `type: module` (need core access), locate their patch site via AOB scan (fail cleanly on unsupported versions), and carry an English description.md. Author: Samurai.

Happy to adjust versions/naming or split into separate entries if preferred. cc @Krarilotus

Generated with Claude Code